### PR TITLE
master-qa-67210

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1214,11 +1214,6 @@
         (database.types == null OR database.types ~ mysql) AND \
         (portal.smoke == true)
 
-    test.batch.run.property.query[functional-smoke-bundle-tcserver-mysql57-jdk8]=\
-        (app.server.types ~ tcserver) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
     test.batch.run.property.query[functional-smoke-bundle-tomcat-db2111-jdk8]=\
         (app.server.types == null OR app.server.types ~ tomcat) AND \
         (database.types == null OR database.types ~ db2) AND \
@@ -3628,7 +3623,6 @@
     test.batch.names[portal-fixpack-release]=\
         functional-bundle-tomcat-mysql57-jdk8,\
         functional-smoke-bundle-jboss-mysql57-jdk8,\
-        functional-smoke-bundle-tcserver-mysql57-jdk8,\
         functional-smoke-bundle-tomcat-db2111-jdk8,\
         functional-smoke-bundle-tomcat-hypersonic20-jdk8,\
         functional-smoke-bundle-tomcat-mariadb102-jdk8,\
@@ -3806,7 +3800,6 @@
     test.batch.names[portal-hotfix-release]=\
         functional-bundle-tomcat-mysql57-jdk8,\
         functional-smoke-bundle-jboss-mysql57-jdk8,\
-        functional-smoke-bundle-tcserver-mysql57-jdk8,\
         functional-smoke-bundle-tomcat-db2111-jdk8,\
         functional-smoke-bundle-tomcat-hypersonic20-jdk8,\
         functional-smoke-bundle-tomcat-mariadb102-jdk8,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-67210
Hi @michaelhashimoto @yichenroy @brianwulbern ,
As tcServer is no longer on the compatibility matrix for 7.3 or for 7.2, I update the properties, will backport to 7.3.x and 7.2.x soon. Let me know if you have concern. See details [here](https://issues.liferay.com/browse/LRP-1321)
7.3.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/34395
7.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/34396